### PR TITLE
Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -255,6 +255,166 @@
         }
       }
     },
+    "babel-cli": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.15.0",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "1.3.2",
+            "async-each": "1.0.1",
+            "fsevents": "1.1.3",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -707,6 +867,25 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
       }
     },
     "babel-preset-es2015": {
@@ -1410,6 +1589,12 @@
         "css-color-names": "0.0.4",
         "has": "1.0.1"
       }
+    },
+    "commander": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
+      "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -2653,6 +2838,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -5273,6 +5464,17 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -7641,6 +7843,12 @@
         "kind-of": "6.0.2"
       }
     },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -7675,6 +7883,15 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/bundle.js",
   "scripts": {
     "build": "webpack",
-    "test": "jasmine",
+    "test": "babel-node spec/run.js",
     "flow": "flow",
     "dev": "webpack-dev-server"
   },
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/trebor/tsomi#readme",
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",

--- a/spec/run.js
+++ b/spec/run.js
@@ -1,0 +1,7 @@
+const Jasmine = require('jasmine')
+const path = require('path')
+
+const jasmine = new Jasmine()
+jasmine.loadConfigFile('spec/support/jasmine.json')
+jasmine.execute()
+

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "src",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true
+}

--- a/src/components/History.js
+++ b/src/components/History.js
@@ -1,0 +1,39 @@
+// @flow
+
+const { last } = require('../util')
+
+class History {
+  past: Array<string>
+  future: Array<string>
+  
+  constructor() {
+    this.past = []
+    this.future = []
+  }
+
+  current() {
+    return last(this.past)
+  }
+
+  goTo(str: string) {
+    this.past.push(str)
+  }
+
+  goBack() {
+    const p = this.past.pop()
+    this.future.push(p)
+    return this.current()
+  }
+
+  goForward() {
+    if(!this.future.length)
+      return false
+
+    const mostRecent = last(this.future)
+    this.past.push(mostRecent)
+    return this.current()
+  }
+}
+
+module.exports = { History }
+

--- a/src/components/History.spec.js
+++ b/src/components/History.spec.js
@@ -1,0 +1,37 @@
+const { History } = require('./History')
+
+describe('History', () => {
+  let h
+
+  beforeEach(() => {
+    h = new History()
+  })
+  
+  it('should initialize empty', () => {
+    expect(h.past).toEqual([])
+    expect(h.future).toEqual([])
+  })
+
+  it('should keep track of past states', () => {
+    const out = [ 'chaucer', 'longfellow', 'williams', 'poe' ]
+    out.forEach(str => h.goTo(str))
+
+    expect(h.past).toEqual(out)
+  })
+
+  it('should be able to go backward in time', () => {
+    h.goTo('chaucer')
+    h.goTo('longfellow')
+
+    h.goBack()
+    expect(h.current()).toEqual('chaucer')
+  })
+  
+  it('should be able to go forward in time', () => {
+    h.goTo('chaucer')
+    h.goTo('longfellow')
+    h.goBack()
+    h.goForward()
+    expect(h.current()).toEqual('longfellow')
+  })
+})

--- a/src/tsomi-rdf.js
+++ b/src/tsomi-rdf.js
@@ -23,7 +23,7 @@ var prefixies = [
   {prefix: 'dcterms',     uri: 'http://purl.org/dc/terms/'},
 ];
 
-export var predicates = {
+var predicates = {
   influenced:    'dbpedia-owl:influenced',
   influencedBy: 'dbpedia-owl:influencedBy',
   depiction: 'foaf:depiction',
@@ -36,7 +36,7 @@ export var predicates = {
   dod: 'dbpedia-owl:deathDate'
 };
 
-export var subjects = {
+var subjects = {
   dylan:      'dbpedia:Bob_Dylan',
   bronte:     'dbpedia:Charlotte_Brontë',
   basil:      'dbpedia:Priya_Basil',
@@ -113,7 +113,7 @@ var specialPeopleData = [
   },
 ];
 
-export function createSpecialData(callback) {
+function createSpecialData(callback) {
 
   // all the accumulated queries
 
@@ -274,7 +274,7 @@ WHERE { \
 ORDER BY DESC(?score) \
 LIMIT 10';
 
-export function searchForPeople(queryString, callback) {
+function searchForPeople(queryString, callback) {
   sparqlQuery(query_search, {search_query: queryString.trim()}, function(data) {
     callback(data.results ? data.results.bindings : []);
   });
@@ -359,7 +359,7 @@ function prefix_uri(prefixies, uri) {
   return result;
 }
 
-export function lengthen(uri, bracket) {
+function lengthen(uri, bracket) {
   var result = uri;
   bracket = bracket || false;
 
@@ -429,7 +429,7 @@ function createMockData() {
   return  mockGraph;
 }
 
-export function getPerson(id, callback) {
+function getPerson(id, callback) {
 
   // if the person is in the cache, use that
 
@@ -568,5 +568,14 @@ function queryDetails(targetGraph, targetId, callback) {
     }
     callback();
   });
+}
+
+
+module.exports = { 
+  createSpecialData, 
+  subjects, 
+  lengthen, 
+  getPerson, 
+  searchForPeople 
 }
 

--- a/src/tsomi.js
+++ b/src/tsomi.js
@@ -1,7 +1,14 @@
-import $ from 'jquery'
-import d3 from 'd3'
-import { createSpecialData, subjects, lengthen, getPerson, searchForPeople } from './tsomi-rdf'
-import { convertSpaces, angleRadians, radial, smallest, largest } from './util'
+const $ = require('jquery')
+const d3 = require('d3')
+const { 
+  createSpecialData, 
+  subjects, 
+  lengthen, 
+  getPerson, 
+  searchForPeople 
+} = require('./tsomi-rdf')
+const { convertSpaces, angleRadians, radial } = require('./util')
+const { History} = require('./components/History')
 
 var width = $('#chart').width();
 var height = $('#chart').height();

--- a/src/util.js
+++ b/src/util.js
@@ -32,8 +32,3 @@ module.exports = {
   radial
 }
 
-
-<<<<<<< HEAD
->>>>>>> added test fixtures, implemented History component
-=======
->>>>>>> d0ac5cda28538d66c67d6f2835b2df277b8eb563

--- a/src/util.js
+++ b/src/util.js
@@ -5,16 +5,31 @@ type Point = {
   y: number
 }
 
-export const convertSpaces = (element: string): string =>
+const convertSpaces = (element: string): string =>
   element.replace('%20', '_').replace(' ', '_')
 
-export const angleRadians = (p1: Point, p2: Point): number =>
+const angleRadians = (p1: Point, p2: Point): number =>
   Math.atan2(p2.y - p1.y, p2.x - p1.x)
 
-export const radial = (point: Point, radius: number, radians: number): Point => ({ 
+const radial = (point: Point, radius: number, radians: number): Point => ({ 
   x: Math.cos(radians) * radius + point.x, 
   y: Math.sin(radians) * radius + point.y
 })
 
-export const smallest = (a : number, b : number): number => a < b ? a : b
-export const largest = (a : number, b : number): number => a > b ? a : b
+const smallest = (a : number, b : number): number => a < b ? a : b 
+const largest = (a : number, b : number): number => a > b ? a : b
+
+const last = <T>(arr: Array<T>): T =>
+  arr[arr.length - 1]
+  
+module.exports = {
+  angleRadians,
+  convertSpaces,
+  largest,
+  last,
+  smallest,
+  radial
+}
+
+
+>>>>>>> added test fixtures, implemented History component


### PR DESCRIPTION
We're not using ES Modules, since babel will "use strict"; if we don't turn off modules, and d3 doesn't work in strict mode.

This PR strips out the `import` statements in favor of CommonJS, as well as adding test fixtures and a History class to keep track of our state history.